### PR TITLE
CDMUM-26 Add nil pointer detection when decoding response

### DIFF
--- a/management/management.go
+++ b/management/management.go
@@ -190,7 +190,7 @@ func (m *Management) request(method, uri string, v interface{}) error {
 		return newError(res.Body)
 	}
 
-	if res.StatusCode != http.StatusNoContent {
+	if v != nil && res.StatusCode != http.StatusNoContent {
 		defer res.Body.Close()
 		return json.NewDecoder(res.Body).Decode(v)
 	}


### PR DESCRIPTION
It seems not reasonable to return a "json: unmarshal(ni)" error every time we delete something. Probably we need to check if the v is nil or not to avoid this problem.